### PR TITLE
Fix spacing on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import (
 
 func main() {
 	opts := SystatusOptions{ Prefix : "/dev"}
-    systatus.Enable(opts)
+	systatus.Enable(opts)
 	http.ListenAndServe(":8080", nil)
 }
 ```


### PR DESCRIPTION
---
name: "Pull Request"
about: "Fix spacing on README"
---

### Description
It looks like the README had a mix of tabs/spaces.

### Related Issue
Link to the related issue, if any (e.g., `Fixes #123`).

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring

### Checklist
- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] I have tested my changes
- [ ] I have updated relevant documentation
- [ ] I have reviewed my code for potential issues

### Additional Notes
Add any other context or comments here.
